### PR TITLE
Demangle object names in printed messages

### DIFF
--- a/gftools/defaults.hpp
+++ b/gftools/defaults.hpp
@@ -5,6 +5,8 @@
 #include<complex>
 #include<iostream>
 #include<utility>
+#include<typeinfo>
+#include<boost/core/demangle.hpp>
 
 
 namespace gftools {
@@ -39,13 +41,17 @@ namespace gftools {
 #define INFO2(MSG)            std::cout << "\t"     << MSG << std::endl;
 #define INFO3(MSG)            std::cout << "\t\t"   << MSG << std::endl;
 #define INFO4(MSG)            std::cout << "\t\t\t" << MSG << std::endl;
-#endif 
+#endif
 
 #ifndef ERROR
 #define MSG_PREFIX            __FILE__ << ":" << __LINE__ << ": "
 #define ERROR(MSG)            std::cerr << MSG_PREFIX << MSG << std::endl;
 #endif
 
+/** Extract demangled name from a type_info object */
+std::string demangled_name(std::type_info const& info) {
+    return boost::core::demangle(info.name());
+}
 
 typedef double real_type;
 typedef std::complex<real_type> complex_type;

--- a/gftools/defaults.hpp
+++ b/gftools/defaults.hpp
@@ -6,8 +6,15 @@
 #include<iostream>
 #include<utility>
 #include<typeinfo>
-#include<boost/core/demangle.hpp>
 
+#include<boost/version.hpp>
+#if BOOST_VERSION >= 105600
+#define BOOST_HAS_DEMANGLE
+#endif
+
+#ifdef BOOST_HAS_DEMANGLE
+#include<boost/core/demangle.hpp>
+#endif
 
 namespace gftools {
 
@@ -50,7 +57,11 @@ namespace gftools {
 
 /** Extract demangled name from a type_info object */
 std::string demangled_name(std::type_info const& info) {
+#ifdef BOOST_HAS_DEMANGLE
     return boost::core::demangle(info.name());
+#else
+    return info.name();
+#endif
 }
 
 typedef double real_type;

--- a/gftools/grid_object.hxx
+++ b/gftools/grid_object.hxx
@@ -185,7 +185,7 @@ std::ostream& operator<<(std::ostream& lhs, const grid_object_base<ContainerType
 template <typename ContainerType, typename ...GridTypes> 
 void grid_object_base<ContainerType,GridTypes...>::savetxt(const std::string& fname) const
 {
-    INFO("Saving " << typeid(*this).name() << " to " << fname);
+    INFO("Saving " << demangled_name(typeid(*this)) << " to " << fname);
     std::ofstream out;
     out.open(fname.c_str());
     size_t total_size = this->size();
@@ -204,7 +204,7 @@ void grid_object_base<ContainerType,GridTypes...>::savetxt(const std::string& fn
 template <typename ContainerType, typename ...GridTypes> 
 void grid_object_base<ContainerType,GridTypes...>::loadtxt(const std::string& fname, real_type tol)
 {
-    INFO("Loading " << typeid(*this).name() << " from " << fname);
+    INFO("Loading " << demangled_name(typeid(*this)) << " from " << fname);
     std::ifstream in;
     in.open(fname.c_str());
     if (in.fail()) { ERROR("Couldn't open file " << fname); throw exIOProblem(); };
@@ -425,7 +425,7 @@ GridObjectType loadtxt(std::string const& fname, double tol)
     typedef typename GridObjectType::value_type value_type;
     typedef typename GridObjectType::grid_tuple grid_tuple;
 
-    INFO("Loading " << typeid(GridObjectType).name() << " from " << fname);
+    INFO("Loading " << demangled_name(typeid(GridObjectType)) << " from " << fname);
     std::ifstream in;
     in.open(fname.c_str());
     if (in.fail()) { ERROR("Couldn't open file " << fname); throw typename GridObjectType::exIOProblem(); };

--- a/gftools/hdf5.hpp
+++ b/gftools/hdf5.hpp
@@ -129,7 +129,7 @@ struct hdf5_grid_tuple<std::tuple<Grid>,N>
 template <typename T> 
 inline void save_grid_object(alps::hdf5::archive & ar, std::string const & path, const T& c, bool plaintext = false, std::string extra_name_to_plaintext = "") 
 {
-    std::cout << "hdf5 : saving " << typeid(T).name() << " to " << path << std::endl;
+    std::cout << "hdf5 : saving " << demangled_name(typeid(T)) << " to " << path << std::endl;
     hdf5_grid_tuple<typename T::grid_tuple>::save(ar,path+"/grids",c.grids());
     save(ar,path+"/data", c.data());
     std::string p2(path);
@@ -144,7 +144,7 @@ inline void save_grid_object(alps::hdf5::archive & ar, std::string const & path,
 
 template <typename T> 
 inline T load_grid_object(alps::hdf5::archive & ar, std::string const & path) {  
-    std::cout << "hdf5 : loading " << typeid(T).name() << " from " << path << std::endl;
+    std::cout << "hdf5 : loading " << demangled_name(typeid(T)) << " from " << path << std::endl;
     auto grids = hdf5_grid_tuple<typename T::grid_tuple>::load(ar,path+"/grids");
     auto data = hdf5_loader<typename T::container_type>::load(ar,path+"/data");
     return T(grids,data);

--- a/gftools/num_io.hpp
+++ b/gftools/num_io.hpp
@@ -27,12 +27,12 @@ public:
     const type &operator()() const{return value_;}
     /// Save the object to a file with a filename passed in as a name
     void savetxt(const std::string& filename) { 
-        std::cout << "Saving " << typeid(*this).name() << " to " << filename << std::endl;
+        std::cout << "Saving " << demangled_name(typeid(*this)) << " to " << filename << std::endl;
         std::ofstream out; out.open(filename.c_str()); out << *this << std::endl; out.close(); 
     }; 
     /// Read the object from a file with a filename passed in as a name
     void loadtxt(const std::string& filename) { 
-        std::cout << "Loading " << typeid(*this).name() << " from " << filename << std::endl;
+        std::cout << "Loading " << demangled_name(typeid(*this)) << " from " << filename << std::endl;
         std::ifstream out; out.open(filename.c_str()); if (out.fail()) throw (std::bad_exception()); out >> *this; out.close(); 
     }; 
     /// Convert the num_io to string


### PR DESCRIPTION
Implementation is trivial and based on boost::core::demangle().