### PR TITLE
Fix compilation warnings

### DIFF
--- a/gftools/container.hxx
+++ b/gftools/container.hxx
@@ -43,7 +43,7 @@ double container_base<ValueType,N, BoostCType>::diff(const container_base<V2,N,D
 template <typename ValueType, size_t N, typename BoostCType> 
 std::array<size_t,N> container_base<ValueType,N, BoostCType>::shape() const 
 {
-    std::array<size_t, N> out; for (int i=0; i<N; i++) out[i] = storage_.shape()[i]; return out; 
+    std::array<size_t, N> out; for (size_t i=0; i<N; i++) out[i] = storage_.shape()[i]; return out;
 }
 
 template <typename ValueType, size_t N, typename BoostCType> 
@@ -76,7 +76,7 @@ template<size_t N2, typename U>
 container_base<ValueType,N, BoostCType>&
     container_base<ValueType,N, BoostCType>::operator=(MatrixType rhs)
 {
-    assert(rhs.rows() == storage_.shape()[0] && rhs.cols() == storage_.shape()[1]);
+    assert((size_t)rhs.rows() == storage_.shape()[0] && (size_t)rhs.cols() == storage_.shape()[1]);
     std::copy(rhs.data(), rhs.data()+rhs.rows()*rhs.cols(), storage_.origin());
     return *this;
 }

--- a/gftools/enum_grid.hpp
+++ b/gftools/enum_grid.hpp
@@ -33,7 +33,7 @@ public:
      * \param[in] include_last True, if the max point needs to be included
      */
     enum_grid(int min, int max, bool include_last = false);
-    enum_grid(const std::vector<int>& in):base( ([&in](){std::vector<typename point::value_type> out(in.size()); for (int i=0; i<out.size(); ++i) out[i]=in[i]; return out; })()) {}
+    enum_grid(const std::vector<int>& in):base( ([&in](){std::vector<typename point::value_type> out(in.size()); for (size_t i=0; i<out.size(); ++i) out[i]=in[i]; return out; })()) {}
     enum_grid(const std::vector<int_wrap_enumerate_grid>& in):base(in){}
     enum_grid(enum_grid&& rhs);
     enum_grid(const enum_grid& rhs):base(rhs){}

--- a/gftools/fft.hpp
+++ b/gftools/fft.hpp
@@ -20,7 +20,7 @@ container<complex_type,D> run_fft (const container_base<complex_type,D,BC> &in, 
     if (direction == FFTW_BACKWARD) out/=norm;
     fftw_destroy_plan(p);
     fftw_cleanup();
-    return std::move(out);
+    return out;
 }
 
 
@@ -39,7 +39,7 @@ container<complex_type,D> run_fft (const container_base<complex_type,D,BC> &in, 
     if (direction == FFTW_BACKWARD) out/=norm;
     fftw_destroy_plan(p);
     fftw_cleanup();
-    return std::move(out);
+    return out;
 }
 
 template <size_t D, typename BC, typename std::enable_if<D==3, bool>::type=0> 
@@ -57,7 +57,7 @@ container<complex_type,D> run_fft (const container_base<complex_type,D,BC> &in, 
     if (direction == FFTW_BACKWARD) out/=norm;
     fftw_destroy_plan(p);
     fftw_cleanup();
-    return std::move(out);
+    return out;
 }
 
 template <size_t D, typename BC, typename std::enable_if<D==4, bool>::type=0> 
@@ -77,7 +77,7 @@ container<complex_type,D> run_fft (const container_base<complex_type,D,BC> &in, 
     if (direction == FFTW_BACKWARD) out/=norm;
     fftw_destroy_plan(p);
     fftw_cleanup();
-    return std::move(out);
+    return out;
 }
 
 

--- a/gftools/grid_base.hpp
+++ b/gftools/grid_base.hpp
@@ -105,18 +105,26 @@ public:
     bool operator==(const grid_base &rhs) const;
 
     class ex_wrong_index : public gftools_exception { public: 
-        ex_wrong_index(int i, int l):index_(i),l_(l){}; 
-        virtual const char* what() const throw(){return std::string("grid_base : index " + std::to_string(index_) + "is out of bounds >" + std::to_string(l_) + ".").c_str();} 
-        int index_; int l_; 
-        };
+        ex_wrong_index(int i, int l):index_(i),l_(l),
+        msg("grid_base : index " + std::to_string(index_) + " is out of bounds >" + std::to_string(l_) + ".")
+        {}
+        virtual const char* what() const throw(){return msg.c_str();}
+        int index_; int l_;
+        std::string msg;
+    };
 
     class ex_not_found : public gftools_exception { public: 
-        ex_not_found(value_type x, grid_base const &y):x_(x), y_(y){}; 
-        virtual const char* what() const throw(){value_type b1(y_[0]), b2(y_[y_.size()-1]); return std::string("grid_base : " + make_num_io(x_).to_string() + " is not found in \
-the grid [" + make_num_io(b1).to_string() + "; " + make_num_io(b2).to_string() + "]." ).c_str();} 
+        ex_not_found(value_type x, grid_base const &y):x_(x), y_(y)
+        {
+            value_type b1(y_[0]), b2(y_[y_.size()-1]);
+            msg = "grid_base : " + make_num_io(x_).to_string() + " is not found in the grid [" +
+                  make_num_io(b1).to_string() + "; " + make_num_io(b2).to_string() + "].";
+        }
+        virtual const char* what() const throw(){return msg.c_str();}
         value_type x_; 
         grid_base const& y_;
-        };
+        std::string msg;
+    };
 
 
 protected:

--- a/gftools/grid_object.hpp
+++ b/gftools/grid_object.hpp
@@ -150,7 +150,7 @@ public:
     value_type& operator()(const point_tuple& in) { return data_(get_indices(in)); }
     value_type operator()(const point_tuple& in) const { 
             try { return data_(get_indices(in)); } 
-            catch (gftools::ex_generic) { return this->tail_eval(in); };
+            catch (gftools::ex_generic&) { return this->tail_eval(in); };
         }
 
     template <int M=N>
@@ -164,7 +164,7 @@ public:
         }
     template <int M=N>
     typename std::enable_if<(M==1 ), value_type>::type  operator()(arg_tuple in) const
-    	{ try { return std::get<0>(grids_).eval(data_, std::get<0>(in)); } catch (gftools::gftools_exception) { return this->tail_eval(in); } }
+        { try { return std::get<0>(grids_).eval(data_, std::get<0>(in)); } catch (gftools::gftools_exception&) { return this->tail_eval(in); } }
 
     template <int M=N>
     typename std::enable_if<(M==1 ), value_type>::type
@@ -200,7 +200,7 @@ public:
     template <typename ArgType>
     	typename std::enable_if<std::is_same<std::tuple<ArgType>, arg_tuple>::value, value_type>::type
     	 operator()(ArgType in) const { try { return std::get<0>(grids_).eval(data_, in); } 
-            catch (gftools::gftools_exception) { return tail_(in); }; }
+            catch (gftools::gftools_exception&) { return tail_(in); }; }
 
     /*template <typename ArgType>
         	typename std::enable_if<std::is_same<std::tuple<ArgType>, arg_tuple>::value, value_type>::type

--- a/gftools/grid_object.hxx
+++ b/gftools/grid_object.hxx
@@ -9,12 +9,12 @@ namespace gftools {
 //
 // grid_object_base
 //
-    
+
 //
 // constructors
 //
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>::grid_object_base( const std::tuple<GridTypes...> &grids):
     grids_(grids),
     dims_(trs::get_dimensions(grids)),
@@ -23,28 +23,28 @@ grid_object_base<ContainerType,GridTypes...>::grid_object_base( const std::tuple
 {
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 template <typename CType>
 grid_object_base<ContainerType,GridTypes...>::grid_object_base( const std::tuple<GridTypes...> &grids, CType& data):
     grids_(grids),
     dims_(trs::get_dimensions(grids)),
     data_(data),
-    tail_(tools::fun_traits<function_type>::constant(0.0)) 
+    tail_(tools::fun_traits<function_type>::constant(0.0))
 {
     if (dims_ != data.shape()) throw gftools::ex_generic("Dimensions mismatch when creating grid_object from existing data");
 };
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>::grid_object_base( const std::tuple<GridTypes...> &grids, ContainerType&& data):
     grids_(grids),
     dims_(trs::get_dimensions(grids)),
     data_(std::forward<ContainerType>(data)),
-    tail_(tools::fun_traits<function_type>::constant(0.0)) 
+    tail_(tools::fun_traits<function_type>::constant(0.0))
 {
     if (dims_ != data.shape()) throw gftools::ex_generic("Dimensions mismatch when creating grid_object from existing data");
 };
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>::grid_object_base( grid_object_base<ContainerType,GridTypes...> && rhs):
     grids_(rhs.grids_),
     dims_(rhs.dims_),
@@ -53,20 +53,20 @@ grid_object_base<ContainerType,GridTypes...>::grid_object_base( grid_object_base
     tail_.swap(rhs.tail_);
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>::grid_object_base( const grid_object_base<ContainerType, GridTypes...>& rhs):
-    grids_(rhs.grids_), 
+    grids_(rhs.grids_),
     dims_(rhs.dims_),
     data_(rhs.data_),
     tail_(rhs.tail_)
 {
-}; 
+};
 
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 template <typename CType>
 grid_object_base<ContainerType,GridTypes...>::grid_object_base( const grid_object_base<CType, GridTypes...>& rhs):
-    grids_(rhs.grids_), 
+    grids_(rhs.grids_),
     dims_(rhs.dims_),
     data_(rhs.data_),
     tail_(rhs.tail_)
@@ -76,7 +76,7 @@ grid_object_base<ContainerType,GridTypes...>::grid_object_base( const grid_objec
 // Assignment
 //
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator= (
     const grid_object_base<ContainerType,GridTypes...>& rhs)
 {
@@ -88,7 +88,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
 }
 
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
     template <typename CType>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator= (
     const grid_object_base<CType,GridTypes...>& rhs)
@@ -99,7 +99,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
     return *this;
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator= (
     const value_type& rhs)
 {
@@ -108,7 +108,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
     return *this;
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator= (
     grid_object_base<ContainerType,GridTypes...>&& rhs)
 {
@@ -123,48 +123,48 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
 // shift
 //
 
-template <typename ContainerType, typename ...GridTypes> 
-template <typename ...ArgTypes> 
+template <typename ContainerType, typename ...GridTypes>
+template <typename ...ArgTypes>
 typename std::enable_if<
-    (std::is_convertible<std::tuple<ArgTypes...>, typename grid_object_base<ContainerType,GridTypes...>::arg_tuple>::value || 
-     std::is_same<std::tuple<ArgTypes...>, typename grid_object_base<ContainerType,GridTypes...>::point_tuple>::value), 
-    grid_object<typename grid_object_base<ContainerType,GridTypes...>::value_type, GridTypes...>>::type 
-        grid_object_base<ContainerType,GridTypes...>::shift (const std::tuple<ArgTypes...>& shift_args) const 
+    (std::is_convertible<std::tuple<ArgTypes...>, typename grid_object_base<ContainerType,GridTypes...>::arg_tuple>::value ||
+     std::is_same<std::tuple<ArgTypes...>, typename grid_object_base<ContainerType,GridTypes...>::point_tuple>::value),
+    grid_object<typename grid_object_base<ContainerType,GridTypes...>::value_type, GridTypes...>>::type
+        grid_object_base<ContainerType,GridTypes...>::shift (const std::tuple<ArgTypes...>& shift_args) const
 {
     grid_object_base<ContainerType,GridTypes...> out(grids_);
-    std::function<value_type(point_tuple)> ShiftFunction = [&](point_tuple args1)->value_type { 
+    std::function<value_type(point_tuple)> ShiftFunction = [&](point_tuple args1)->value_type {
         try { point_tuple out_args = trs::shift(args1, shift_args,grids_); return (*this)(out_args); }
-        catch (...) 
+        catch (...)
             { arg_tuple out_args = trs::shift(arg_tuple(args1), arg_tuple(shift_args) ,grids_); return (*this)(out_args); }
-    //    __tuple_print<point_tuple>::print(args1); 
-    //    INFO_NONEWLINE("+");  __tuple_print<std::tuple<ArgTypes...>>::print(shift_args); 
+    //    __tuple_print<point_tuple>::print(args1);
+    //    INFO_NONEWLINE("+");  __tuple_print<std::tuple<ArgTypes...>>::print(shift_args);
     //    INFO_NONEWLINE("-->");__tuple_print<point_tuple>::print(out_args);
         };
     out.fill(ShiftFunction);
-    
+
     static std::function<value_type(arg_tuple)> ShiftAnalyticF;
     ShiftAnalyticF = [this, shift_args](const arg_tuple& in)->value_type {
-        arg_tuple out_args = trs::shift(in,shift_args,grids_); 
+        arg_tuple out_args = trs::shift(in,shift_args,grids_);
         return tuple_tools::unfold_tuple(this->tail_, out_args);
     };
-    
+
     function_type tailF = tools::extract_tuple_f(ShiftAnalyticF);
     out.tail_ = tailF;
-    
+
     return out;
-} 
+}
 
 //
 // IO
 //
 
-namespace extra { 
+namespace extra {
 template <size_t D>
 inline std::array<size_t, D> enumerate_indices_(const size_t index, const std::array<size_t, D> dims)
 {
     std::array<size_t, D> indices;
     size_t t = index;
-    for (int i=D-1; i>=0; i--) { 
+    for (int i=D-1; i>=0; i--) {
         indices[i]=t%dims[i];
         t-=indices[i];
         t/=dims[i];
@@ -173,7 +173,7 @@ inline std::array<size_t, D> enumerate_indices_(const size_t index, const std::a
 }
 } // end of namespace extra
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 std::ostream& operator<<(std::ostream& lhs, const grid_object_base<ContainerType,GridTypes...> &in)
 {
     lhs << (in.data_);
@@ -182,7 +182,7 @@ std::ostream& operator<<(std::ostream& lhs, const grid_object_base<ContainerType
 
 
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 void grid_object_base<ContainerType,GridTypes...>::savetxt(const std::string& fname) const
 {
     INFO("Saving " << demangled_name(typeid(*this)) << " to " << fname);
@@ -201,7 +201,7 @@ void grid_object_base<ContainerType,GridTypes...>::savetxt(const std::string& fn
     out.close();
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 void grid_object_base<ContainerType,GridTypes...>::loadtxt(const std::string& fname, real_type tol)
 {
     INFO("Loading " << demangled_name(typeid(*this)) << " from " << fname);
@@ -228,7 +228,7 @@ void grid_object_base<ContainerType,GridTypes...>::loadtxt(const std::string& fn
 // Fill values
 //
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 void grid_object_base<ContainerType,GridTypes...>::fill_point_function(const typename grid_object_base<ContainerType,GridTypes...>::point_function_type& in)
 {
     size_t total_size = this->size();
@@ -240,7 +240,7 @@ void grid_object_base<ContainerType,GridTypes...>::fill_point_function(const typ
         };
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 void grid_object_base<ContainerType,GridTypes...>::fill_function(const typename grid_object_base<ContainerType,GridTypes...>::function_type& in)
 {
     size_t total_size = this->size();
@@ -253,7 +253,7 @@ void grid_object_base<ContainerType,GridTypes...>::fill_function(const typename 
     tail_ = in;
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 template <typename CType2>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::copy_interpolate (
     const grid_object_base<CType2,GridTypes...>& rhs)
@@ -271,8 +271,8 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
 // Math (obsolete)
 //
 /*
-template <typename ContainerType, typename ...GridTypes> 
-template <typename ...ArgTypes> 
+template <typename ContainerType, typename ...GridTypes>
+template <typename ...ArgTypes>
 inline grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator= (
     const std::function<value_type(ArgTypes...)> & in)
 {
@@ -281,7 +281,7 @@ inline grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerT
 }
 */
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator+= (
     const grid_object_base<ContainerType,GridTypes...>& rhs)
 {
@@ -291,7 +291,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
     return *this;
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator+= (
     const value_type & rhs)
 {
@@ -301,7 +301,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
 }
 
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator*= (
     const grid_object_base<ContainerType,GridTypes...>& rhs)
 {
@@ -311,7 +311,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
     return *this;
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator*= (
     const value_type & rhs)
 {
@@ -321,7 +321,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
 }
 
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator/= (
     const grid_object_base<ContainerType,GridTypes...>& rhs)
 {
@@ -331,7 +331,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
     return *this;
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator/= (
     const value_type & rhs)
 {
@@ -341,7 +341,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
 }
 
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator-= (
     const grid_object_base<ContainerType,GridTypes...>& rhs)
 {
@@ -351,7 +351,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
     return *this;
 }
 
-template <typename ContainerType, typename ...GridTypes> 
+template <typename ContainerType, typename ...GridTypes>
 grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,GridTypes...>::operator-= (
     const value_type & rhs)
 {
@@ -361,7 +361,7 @@ grid_object_base<ContainerType,GridTypes...>& grid_object_base<ContainerType,Gri
 }
 
 
-namespace extra { 
+namespace extra {
 
     template <typename GridTupleType, typename OrigGridTupleType, int N>
     struct GridTupleFromVector
@@ -374,9 +374,9 @@ namespace extra {
         static GridTupleType extract(vector_type const& in) {
             std::unordered_set<value_type, boost::hash<value_type>> vals_set;
             std::vector<value_type> vals_vec;
-            for (int i=0; i<in.size(); i++) { 
+            for (size_t i=0; i<in.size(); i++) {
                 value_type v = std::get<TupleSize - N>(in[i]);
-                auto x = vals_set.insert(v); 
+                auto x = vals_set.insert(v);
                 if (x.second) vals_vec.push_back(v);
                 }
             return std::tuple_cat(
@@ -385,7 +385,7 @@ namespace extra {
                 );
             }
     };
-    
+
     template <typename GridTupleType, typename OrigGridTupleType>
     struct GridTupleFromVector<GridTupleType, OrigGridTupleType, 1>
     {
@@ -398,21 +398,21 @@ namespace extra {
             static_assert(std::tuple_size<GridTupleType>::value == 1, "wrong tuple size");
             std::unordered_set<value_type, boost::hash<value_type>> vals_set;
             std::vector<value_type> vals_vec;
-            for (int i=0; i<in.size(); i++) { 
+            for (size_t i=0; i<in.size(); i++) {
                 value_type v = std::get<TupleSize - N>(in[i]);
-                auto x = vals_set.insert(v); 
+                auto x = vals_set.insert(v);
                 if (x.second) vals_vec.push_back(v);
                 }
-            return std::forward_as_tuple(grid_type(vals_vec)); 
+            return std::forward_as_tuple(grid_type(vals_vec));
             }
     };
-    
+
 
 
     template <typename GridTuple>
     GridTuple arg_vector_to_grid_tuple(std::vector<typename tools::grid_tuple_traits<GridTuple>::arg_tuple> const& in)
     {
-        constexpr int ngrids =  std::tuple_size<GridTuple>::value; 
+        constexpr int ngrids =  std::tuple_size<GridTuple>::value;
         return GridTupleFromVector<GridTuple,GridTuple,ngrids>::extract(in);
     }
 }
@@ -433,21 +433,21 @@ GridObjectType loadtxt(std::string const& fname, double tol)
     std::vector<arg_tuple> grid_vals;
     std::vector<value_type> vals;
 
-    while (!in.eof()) {  
+    while (!in.eof()) {
         arg_tuple pts = tuple_tools::read_tuple<arg_tuple>(in); // ensure serialize_tuple in savetxt has the same type. Dropping here indices - they're wrong anyway.
         if (in.eof()) break;
-        value_type v; 
-        in >> num_io<value_type>(v); 
+        value_type v;
+        in >> num_io<value_type>(v);
         grid_vals.push_back(pts);
         vals.push_back(v);
         }
 
-//    for (int i=0; i<grid_vals.size(); i++) 
+//    for (int i=0; i<grid_vals.size(); i++)
 //        DEBUG(tuple_tools::print_tuple(grid_vals[i]));
 
     grid_tuple grids = extra::arg_vector_to_grid_tuple<grid_tuple>(grid_vals);
     GridObjectType out(grids);
-    std::copy(vals.begin(), vals.end(), out.data().data()); 
+    std::copy(vals.begin(), vals.end(), out.data().data());
     return out;
 }
 

--- a/gftools/grid_tools.hpp
+++ b/gftools/grid_tools.hpp
@@ -174,7 +174,7 @@ inline bool grid_tuple_traits<std::tuple<GridTypes...>>::is_equal_(
 {
     std::array<bool, N> arr = {{ std::get<S>(g1) == std::get<S>(g2) ... }};
     bool ok = true;
-    for (int i=0; i<N && ok; i++) { ok = ok && arr[i]; }
+    for (size_t i=0; i<N && ok; i++) { ok = ok && arr[i]; }
     return ok;
 }
 //impl

--- a/gftools/kmesh.hpp
+++ b/gftools/kmesh.hpp
@@ -8,7 +8,7 @@
 #include "grid_base.hpp"
 #include "almost_equal.hpp"
 
-namespace gftools { 
+namespace gftools {
 
 ///this class implements a regular equidistant grid, typically used as a regular k-space grid between 0 and 2PI.
 ///lower boundary is always zero
@@ -25,9 +25,9 @@ public:
     kmesh():npoints_(0){};
     ///constructor from a vector of regularly spaced ints
     kmesh(std::vector<real_type> const& in);
-   
+
     ///given a double 'in', it finds that double in the grid.
-    ///The first return value is whether it has been found or not 
+    ///The first return value is whether it has been found or not
     ///The second return value is the index.
     ///The third return value 'weight' measures how close the point is to a grid point
     std::tuple <bool, size_t, real_type> find(real_type in) const ;
@@ -35,8 +35,8 @@ public:
     template <class Obj> auto integrate(const Obj &in) const -> typename std::result_of<Obj(decltype(vals_[0]))>::type;
     template <class Obj> auto eval(Obj &in, real_type x) const ->decltype(in[0]);
     template <class Obj> auto eval(Obj &in, point x) const ->decltype(in[0]) { return base::eval(in,x); }
-   
-    ///shift implements a periodic operator+ in three variants 
+
+    ///shift implements a periodic operator+ in three variants
     real_type shift(real_type in,real_type shift_arg) const;
     point shift(point in, real_type shift_arg) const { return static_cast<const base*>(this)->shift(in,shift_arg); }
     point shift(point in, point shift_arg) const { return static_cast<const base*>(this)->shift(in,shift_arg); }
@@ -64,8 +64,8 @@ inline kmesh::kmesh(std::vector<real_type> const& in):
     if (vals_.size() <= 1) throw gftools::ex_generic("Can't construct a kmesh with <= 1 element");
     double diff = vals_[1] - vals_[0];
     bool ok = true;
-    for (int i=1; i<vals_.size() && ok; i++) { 
-         ok = almost_equal(vals_[i] - vals_[i-1], diff, diff * 1e-6); 
+    for (size_t i=1; i<vals_.size() && ok; i++) {
+         ok = almost_equal(vals_[i] - vals_[i-1], diff, diff * 1e-6);
         }
     if (!ok) throw gftools::ex_generic("kmesh should be uniform");
     domain_len_ = vals_.size() * diff;
@@ -78,7 +78,7 @@ inline std::tuple <bool, size_t, real_type> kmesh::find(real_type in) const
     assert(in>=0 && in < domain_len_);
     int n = std::lround(in/domain_len_*npoints_);
     if (n<0) { ERROR("kmesh point is out of bounds, " << in << "<" << 0); return std::make_tuple(false,0,0); };
-    if (n==npoints_) n=0; 
+    if (n==npoints_) n=0;
     if (n>npoints_) { ERROR("kmesh point is out of bounds, " << in << ">" << domain_len_); return std::make_tuple(false,npoints_,0); };
     real_type weight=in/domain_len_*npoints_-real_type(n);
     return std::make_tuple (true,n,weight);
@@ -86,17 +86,17 @@ inline std::tuple <bool, size_t, real_type> kmesh::find(real_type in) const
 
 
 template <class Obj>
-inline auto kmesh::eval(Obj &in, real_type x) const ->decltype(in[0]) 
+inline auto kmesh::eval(Obj &in, real_type x) const ->decltype(in[0])
 {
 	auto p = find_nearest(x);
     return eval(in,p);
 }
 
-template <class Obj> 
+template <class Obj>
 auto kmesh::integrate(const Obj &in) const -> typename std::result_of<Obj(decltype(vals_[0]))>::type
 {
     decltype(in(vals_[0])) R = in(real_type(vals_[0]));
-    R=std::accumulate(vals_.begin()+1, vals_.end(), R,[&](decltype(in(vals_[0]))& y,decltype(vals_[0]) & x) {return y+in(x);}); 
+    R=std::accumulate(vals_.begin()+1, vals_.end(), R,[&](decltype(in(vals_[0]))& y,decltype(vals_[0]) & x) {return y+in(x);});
     return R/npoints_;
 }
 
@@ -104,7 +104,7 @@ inline real_type kmesh::shift(real_type in, real_type shift_arg) const
 {
     assert (in>=0 && in < domain_len_);
     real_type out;
-    out = in + real_type(shift_arg); 
+    out = in + real_type(shift_arg);
     out-= domain_len_*(almost_equal(out, domain_len_, num_io<double>::tolerance())?1.0:std::floor(out/domain_len_));
     return out;
 }

--- a/gftools/real_grid.hpp
+++ b/gftools/real_grid.hpp
@@ -158,9 +158,9 @@ inline std::tuple <bool, size_t, real_type> real_grid::find(real_type in) const
     if (in>max_) { ERROR("Point to find is out of bounds, " << in << ">" << max_ ); return std::make_tuple(0,vals_.size(),0); };
     auto out = std::lower_bound (vals_.begin(), vals_.end(), in);
     size_t i = size_t(out-vals_.begin());
+    if (i==0) return std::make_tuple(1,0,1.0);
     i--;
     if (i==vals_.size()-1) return std::make_tuple(1,i,1.0);
-    if (i==-1) return std::make_tuple(1,0,1.0);
     real_type val_i = vals_[i];
     real_type weight=(in-val_i)/(vals_[i+1] - val_i);
     return std::make_tuple (1,i,weight);

--- a/gftools/tuple_tools.hpp
+++ b/gftools/tuple_tools.hpp
@@ -116,7 +116,7 @@ std::string print_tuple(TT t1){
 
 template <typename Arg, size_t D>
 std::string print_array(const std::array<Arg,D>& t1){
-    std::stringstream out; for (auto x:t1) out << x << " " << std::flush; return std::move<std::string>(out.str()); }
+    std::stringstream out; for (auto x:t1) out << x << " " << std::flush; return out.str(); }
 
 /// Read a tuple from a stream;
 template<typename TT>

--- a/test/container_test.cpp
+++ b/test/container_test.cpp
@@ -117,7 +117,7 @@ TEST_F(cont_test, Iterators) {
 TEST_F(cont_test, Flatten) {
     auto f = (*d2).flatten();
     EXPECT_EQ(f.size(), (*d2).size());
-    EXPECT_EQ(f.shape()[0], (*d2).size());
+    EXPECT_EQ(f.shape()[0], size_t((*d2).size()));
 }
 
 TEST_F(cont_test, as_matrix) {

--- a/test/eval_expression_test.cpp
+++ b/test/eval_expression_test.cpp
@@ -14,7 +14,7 @@ TEST(expression1d, vector) {
     std::iota(y.begin(), y.end(), 0.3);
     eval_expression<std::vector<double>, double, 1> e(y);
     std::cout <<  y[2] << "==" << e[2] << std::endl;
-    for (int i=0; i<y.size(); ++i) { 
+    for (size_t i=0; i<y.size(); ++i) {
         ASSERT_EQ(y[i], e[i]);
         };
 }
@@ -24,7 +24,7 @@ TEST(expression1d, container) {
     std::iota(&y[0], &y[9], 0.3);
     eval_expression<container<double, 1>, double, 1> e(y);
     std::cout <<  y[2] << "==" << e[2] << std::endl;
-    for (int i=0; i<y.size(); ++i) { 
+    for (int i=0; i<y.size(); ++i) {
         ASSERT_EQ(y[i], e[i]);
         };
 }
@@ -39,8 +39,8 @@ TEST(expression2d, vector) {
     std::cout << "expression : " << e[2][3] << std::endl;
     DEBUG(y[2][3] + y[1][2]);
     DEBUG(e[2][3] + e[1][2]);
-    for (int i1 = 0; i1 < dims[0]; i1++) 
-        for (int i2 = 0; i2 < dims[1]; i2++) 
+    for (size_t i1 = 0; i1 < dims[0]; i1++)
+        for (size_t i2 = 0; i2 < dims[1]; i2++)
             ASSERT_EQ(y[i1][i2], e[i1][i2]);
 }
 
@@ -52,8 +52,8 @@ TEST(expression2d, container) {
     eval_expression<data2d, double, 2> e(y);
     std::cout << "original   : " << y[2][3] << std::endl;
     std::cout << "expression : " << e[2][3] << std::endl;
-    for (int i1 = 0; i1 < dims[0]; i1++) 
-        for (int i2 = 0; i2 < dims[1]; i2++) 
+    for (size_t i1 = 0; i1 < dims[0]; i1++)
+        for (size_t i2 = 0; i2 < dims[1]; i2++)
             ASSERT_EQ(y[i1][i2], e[i1][i2]);
     };
 
@@ -61,14 +61,14 @@ TEST(expression2d, grid_object) {
     typedef grid_object<double, real_grid, real_grid> data2d;
     std::array<size_t, 2> dims = {{10, 4}};
     data2d y(real_grid(0,1.,dims[0]), real_grid(0,1.,dims[1]));
-    typename data2d::function_type f1; 
+    typename data2d::function_type f1;
     f1 = [](double x, double y){return sin(x+y);}; // intel bug
     y.fill(f1);
     eval_expression<data2d, double, 2> e(y);
     std::cout << "original   : " << y[2][3] << std::endl;
     std::cout << "expression : " << e[2][3] << std::endl;
-    for (int i1 = 0; i1 < dims[0]; i1++) 
-        for (int i2 = 0; i2 < dims[1]; i2++) 
+    for (size_t i1 = 0; i1 < dims[0]; i1++)
+        for (size_t i2 = 0; i2 < dims[1]; i2++)
             ASSERT_EQ(y[i1][i2], e[i1][i2]);
     };
 
@@ -81,9 +81,9 @@ TEST(expression3d, vector) {
     eval_expression<data3d, double, 3> e(y);
     std::cout << "original   : " <<  y[2][3][5] << std::endl;
     std::cout << "expression : " <<  e[2][3][5] << std::endl;
-    for (int i1 = 0; i1 < dims[0]; i1++) 
-        for (int i2 = 0; i2 < dims[1]; i2++) 
-            for (int i3 = 0; i3 < dims[2]; i3++) 
+    for (size_t i1 = 0; i1 < dims[0]; i1++)
+        for (size_t i2 = 0; i2 < dims[1]; i2++)
+            for (size_t i3 = 0; i3 < dims[2]; i3++)
                 ASSERT_EQ(y[i1][i2][i3], e[i1][i2][i3]);
 }
 
@@ -95,9 +95,9 @@ TEST(expression3d, container) {
     eval_expression<data3d, double, 3> e(y);
     std::cout << "original   : " <<  y[2][3][5] << std::endl;
     std::cout << "expression : " <<  e[2][3][5] << std::endl;
-    for (int i1 = 0; i1 < dims[0]; i1++) 
-        for (int i2 = 0; i2 < dims[1]; i2++) 
-            for (int i3 = 0; i3 < dims[2]; i3++) 
+    for (size_t i1 = 0; i1 < dims[0]; i1++)
+        for (size_t i2 = 0; i2 < dims[1]; i2++)
+            for (size_t i3 = 0; i3 < dims[2]; i3++)
                 ASSERT_EQ(y[i1][i2][i3], e[i1][i2][i3]);
 }
 

--- a/test/grid_object_test.cpp
+++ b/test/grid_object_test.cpp
@@ -111,7 +111,7 @@ TEST_F(gridobject_test1, Reductions)
     DEBUG(print_tuple(t2));
     auto t3 = gf.get_args(t1);
     EXPECT_EQ(is_float_equal(t3,t2),1);
-    EXPECT_EQ(gf.size(), 4*10*8);
+    EXPECT_EQ(gf.size(), size_t(4*10*8));
 
     gf_t gf2(gf);
     gf2[0][0][0] = 0.5;

--- a/test/grid_test.cpp
+++ b/test/grid_test.cpp
@@ -29,7 +29,8 @@ int main()
     
     my_grid g2 ( { my_data(1), my_data(2), my_data(5) });
     std::cout << g2 << std::endl;
-    for (auto p : g2.points()) std::cout << p << " "; std::cout << std::endl;
+    for (auto p : g2.points()) std::cout << p << " ";
+    std::cout << std::endl;
 
     typedef my_grid::point point;
     point p1 = g2[2];

--- a/test/grid_tools_test.cpp
+++ b/test/grid_tools_test.cpp
@@ -50,9 +50,9 @@ public:
 
 // check construction
 TEST_F(grid_tuple_test, Construction) {
-    EXPECT_EQ(std::get<0>(*grids_ptr).size(), 4);
-    EXPECT_EQ(std::get<1>(*grids_ptr).size(), 12);
-    EXPECT_EQ(std::get<2>(*grids_ptr).size(), 8);
+    EXPECT_EQ(std::get<0>(*grids_ptr).size(), (size_t)4);
+    EXPECT_EQ(std::get<1>(*grids_ptr).size(), (size_t)12);
+    EXPECT_EQ(std::get<2>(*grids_ptr).size(), (size_t)8);
 }
 
 TEST_F(grid_tuple_test, IndexOp) {
@@ -61,10 +61,10 @@ TEST_F(grid_tuple_test, IndexOp) {
     std::cout << "p : " << print_tuple(p) << std::endl;
     typename trs::indices i1 = trs::get_indices(p, g);
     std::cout << "indices : " << print_array(i1) << std::endl;
-    EXPECT_EQ(i1[0], 1);
-    EXPECT_EQ(i1[1], 2);
-    EXPECT_EQ(i1[2], 4);
-    
+    EXPECT_EQ(i1[0], (size_t)1);
+    EXPECT_EQ(i1[1], (size_t)2);
+    EXPECT_EQ(i1[2], (size_t)4);
+
     typename trs::indices i2 = {{2,5,3,1}};
     typename trs::point_tuple p2 = trs::points(i2,g);
     typename trs::indices i22 = trs::get_indices(p2, g);
@@ -93,18 +93,18 @@ TEST_F(grid_tuple_test, Globals) {
     const auto& g = grids();
     auto dims = trs::get_dimensions(g);
     std::cout << print_array(dims) << std::endl;
-    EXPECT_EQ(dims[0], 4); 
-    EXPECT_EQ(dims[1], 12); 
-    EXPECT_EQ(dims[2], 8); 
-    EXPECT_EQ(dims[3], 100); 
+    EXPECT_EQ(dims[0], (size_t)4);
+    EXPECT_EQ(dims[1], (size_t)12);
+    EXPECT_EQ(dims[2], (size_t)8);
+    EXPECT_EQ(dims[3], (size_t)100);
 
     size_t s = trs::get_total_size(g);
     std::cout << "size : " << s << std::endl;
-    EXPECT_EQ(s,4*12*8*100);
+    EXPECT_EQ(s, size_t(4*12*8*100));
 }
 
 TEST_F(grid_tuple_test, PointShift) {
-    const auto& g2 = grids2(); 
+    const auto& g2 = grids2();
     trs2::point_tuple p1 = trs2::find_nearest(std::make_tuple(2,M_PI),g2);
     std::cout << "p1" << print_tuple(p1) << std::endl;
 
@@ -112,7 +112,7 @@ TEST_F(grid_tuple_test, PointShift) {
     trs2::point_tuple shift2 = trs2::find_nearest(shift1,g2);
 
     trs2::point_tuple r1 = trs2::find_nearest(std::make_tuple(3,0.),g2);
-    
+
     trs2::point_tuple p1s1 = trs2::shift(p1,shift1,g2);
     std::cout << print_tuple(p1) << "+" << print_tuple(shift1) << " = " << print_tuple(p1s1) << std::endl;
     EXPECT_EQ(p1s1, r1);
@@ -123,7 +123,7 @@ TEST_F(grid_tuple_test, PointShift) {
 }
 
 TEST_F(grid_tuple_test, ArgShift) {
-    const auto& g = grids(); 
+    const auto& g = grids();
     trs::point_tuple p1 = trs::find_nearest(std::make_tuple(2,FMatsubara(2,beta),M_PI, 3. ),g);
 
     trs::arg_tuple shift1 = std::make_tuple(1,BMatsubara(0,beta),5*M_PI/4.,4.);
@@ -146,22 +146,22 @@ TEST_F(grid_tuple_test, ArgShift) {
 }
 
 TEST_F(grid_tuple_test, ArgShiftFail) {
-    const auto& g = grids(); 
+    const auto& g = grids();
     trs::point_tuple p1 = trs::find_nearest(std::make_tuple(2,FMatsubara(2,beta),M_PI, 3. ),g);
 
     double rstep = (std::get<3>(g)[1] - std::get<3>(g)[0]);
 
     // last index out of bounds
-    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(1,BMatsubara(0,beta),5*M_PI/4.,rstep*100),g)); 
+    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(1,BMatsubara(0,beta),5*M_PI/4.,rstep*100),g));
     // can't shift fermionic Matsubara over another fermionic Matsubara and get a Fermionic Matsubara
-    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(1,FMatsubara(0,beta),5*M_PI/4.,rstep),g)); 
+    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(1,FMatsubara(0,beta),5*M_PI/4.,rstep),g));
     // first index out of bounds
-    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(4,BMatsubara(0,beta),5*M_PI/4.,rstep),g)); 
+    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(4,BMatsubara(0,beta),5*M_PI/4.,rstep),g));
 
     // grid point mismatch - one can only shift to the exact point on the grid. Otherwise use find_nearest(arg_tuple)
-    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(0,BMatsubara(0,beta),5*M_PI/8.,rstep),g)); 
+    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(0,BMatsubara(0,beta),5*M_PI/8.,rstep),g));
     // grid point mismatch - one can only shift to the exact point on the grid. Otherwise use find_nearest(arg_tuple)
-    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(0,BMatsubara(0,beta),5*M_PI/4.,rstep/2),g)); 
+    ASSERT_ANY_THROW(trs::shift(p1,std::make_tuple(0,BMatsubara(0,beta),5*M_PI/4.,rstep/2),g));
 
     trs::arg_tuple a1 = trs::shift(trs::get_args(p1,g), std::make_tuple(0,0.,0.,rstep / 3.),g);
     EXPECT_EQ(trs::find_nearest(a1,g),p1);
@@ -169,28 +169,28 @@ TEST_F(grid_tuple_test, ArgShiftFail) {
 
 /* // TODO
 TEST(grids, EvaluateExprTemp1) {
-    
+
     int size = 10;
     std::vector<double> d(size);
     for (int i=0; i<size; i++) d[i]=double(i)/(size);
     kmesh k1(size);
 
-    grid_eval_expr<decltype(d), std::tuple<kmesh>> expr1 (d,std::forward_as_tuple(k1)); 
+    grid_eval_expr<decltype(d), std::tuple<kmesh>> expr1 (d,std::forward_as_tuple(k1));
     //EXPECT_EQ(d[3], expr1[3]);
     DEBUG((std::is_same<std::vector<double>, std::vector<double>>::value));
 
     std::vector<std::vector<double>> d2(size);
     for (int i=0; i<size; i++) { d2[i].resize(size); for (int j=0; j<size; j++) d2[i][j] = double(i+j)/size/size; }
-    
-    //grid_eval_expr<decltype(d2), std::tuple<kmesh,kmesh>> expr2 (d2,std::forward_as_tuple(k1,k1)); 
+
+    //grid_eval_expr<decltype(d2), std::tuple<kmesh,kmesh>> expr2 (d2,std::forward_as_tuple(k1,k1));
     //DEBUG(d2[2][3]);
     //DEBUG(expr2[2][3]);
-    
+
     }
 */
 
 
-int main(int argc, char **argv) 
+int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
This PR fixes most of the `-Wall` compilation warnings (one of them reveals an actual bug).

There is one more thing, which I am not sure how to fix (could potentially be a bug too).

```
gftools/real_grid.hpp:163:10: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
  163 |     if (i==-1) return std::make_tuple(1,0,1.0);
```