### PR TITLE
Small fixes for rare build failures

### DIFF
--- a/gftools/eval_expression.hpp
+++ b/gftools/eval_expression.hpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 #include <array>
+#include <cstddef>
 
 //#include "tuple_tools.hpp" // only for debug
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,6 @@ grid_object_test
 foreach (test ${tests})
     set(test_src ${test}.cpp)
     add_executable(${test} ${test_src})
-    target_link_libraries(${test} gtest_main gftools)
+    target_link_libraries(${test} gtest gtest_main gftools)
     add_test(${test} ${test})
 endforeach(test)


### PR DESCRIPTION
This PR contains two small fixes for build failures which occur in certain setups.

1. Some versions of GCC want an explicit `#include <cstddef>` for `size_t` to be available.
2. In some build configurations of GTest, explicit linkage with the `gtest` target is required in addition to `gtest_main`.

Please also tag a new release. Currently Pomerol has to be built against a Git checkout of gftools. The latest release version is too old and does not provide CMake imported targets.